### PR TITLE
Style webdev tag as sparkly yellow (CSS only)

### DIFF
--- a/components/ArticleTag.vue
+++ b/components/ArticleTag.vue
@@ -58,8 +58,72 @@ a::before {
   color: #fff;
 }
 .webdev {
-  background-color: #562765;
-  color: #fff;
+  position: relative;
+  overflow: hidden;
+  color: #3d2a00;
+  border-color: #c9a227;
+  background: linear-gradient(
+    125deg,
+    #ffd700 0%,
+    #ffec8b 18%,
+    #ffe135 38%,
+    #fffef0 50%,
+    #ffd700 62%,
+    #daa520 82%,
+    #ffec8b 100%
+  );
+  background-size: 280% 280%;
+  animation: webdev-sparkle 3.5s ease-in-out infinite;
+  text-shadow: 0 0 2px rgb(255 255 255 / 75%);
+}
+
+.webdev::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    110deg,
+    transparent 0%,
+    transparent 40%,
+    rgb(255 255 255 / 65%) 50%,
+    transparent 60%,
+    transparent 100%
+  );
+  transform: translateX(-120%);
+  animation: webdev-shine 2.6s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes webdev-sparkle {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+@keyframes webdev-shine {
+  0% {
+    transform: translateX(-120%);
+  }
+  25%,
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .webdev {
+    animation: none;
+    background-size: 100% 100%;
+  }
+
+  .webdev::after {
+    display: none;
+  }
 }
 .productivity {
   background-color: #2a0798;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `webdev` article tag in `ArticleTag.vue` from the previous purple pill to a **gold/yellow** treatment with a subtle “sparkle” effect using **CSS only**:

- Animated multi-stop yellow/gold gradient background
- Periodic highlight sweep via `::after` (does not affect click targets; `pointer-events: none`)
- Light text glow for contrast on bright gold
- `prefers-reduced-motion: reduce` disables motion and the shine overlay

## Testing

- `npm run lint:style`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caab90eb-17a2-44c3-9e9b-533f91d73c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caab90eb-17a2-44c3-9e9b-533f91d73c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

